### PR TITLE
HTTPS Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@ Delicious strips of cured meat!
 
 ## What is _this_ bacon?
 
-A Continuous Integration Daemon for Job Management
+Bacon will be a simple `HTTP` based server that will issue commands to the host. It’s a continuous integration model built on top of `SCM` and `HTTP`, that buys in to the notion of archetecture as software.
+
+The basic idea  is that you specify a list of methods in a `Baconfile` - which is a `JSON` structure. This specification is called a `party` and once you’ve given a server (or `piggy`) a the `Baconfile` the `piggy` becomes the `party` `leader`. Then other little `piggies` can request to `join` the `party` over a `JSON HTTP` interface (I think it will actually be `HTTPS`, it should all be wrapped up in `SSL` from the start.)
+
+Once the `piggies` have joined the `party` the `party` `leader` can issue commands to the `party` `members` with the `methods` from the `Baconfile`.
 
 ## License
 
+```
 Copyright (c) 2016, Myke Atkinson
 All rights reserved.
 
@@ -32,7 +37,4 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies,
-either expressed or implied, of the FreeBSD Project.
+```

--- a/README.md
+++ b/README.md
@@ -6,10 +6,15 @@ Delicious strips of cured meat!
 
 ## What is _this_ bacon?
 
-A Continuous Integration Daemon for Job Management
+Bacon will be a simple `HTTP` based server that will issue commands to the host. It’s a continuous integration model built on top of `SCM` and `HTTP`, that buys in to the notion of infrastructure as code.
+
+The basic idea  is that you specify a list of methods in a `Baconfile` - which is a `JSON` structure. This specification is called a `party` and once you’ve given a server (or `piggy`) the `Baconfile` the `piggy` becomes the `party` `leader`. Then other little `piggies` can request to `join` the `party` over a `JSON HTTP` interface (I think it will actually be `HTTPS`, it should all be wrapped up in `SSL` from the start.)
+
+Once the `piggies` have joined the `party` the `party` `leader` can issue commands to the `party` `members` with the `methods` from the `Baconfile`.
 
 ## License
 
+```
 Copyright (c) 2016, Myke Atkinson
 All rights reserved.
 
@@ -32,7 +37,4 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
 ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies,
-either expressed or implied, of the FreeBSD Project.
+```


### PR DESCRIPTION
A simple server that creates it own certificates when it starts up, and then serves HTTPS.

bacond will do this by default, so that it's securer out of the box.
